### PR TITLE
Keep cursor position after inserting closing tag in closeHTMLTagInPlace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+/.vscode-test
+/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the "vscode-closetag" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+### Fixed
+- ([#11](https://github.com/compulim/vscode-closetag/issues/11)) Fix in-place should not move cursor, by [`@rbolsius`](https://github.com/rbolsius) in [PR #12](https://github.com/compulim/vscode-closetag/pull/12)
+
 ## [1.1.1](https://github.com/compulim/vscode-closetag/releases/tag/v1.1.1) - 2018-06-09
 ### Fixed
 - ([#15](https://github.com/compulim/vscode-closetag/issues/15)) Fix broken under VSCode 1.24.0

--- a/extension.js
+++ b/extension.js
@@ -28,26 +28,26 @@ function activate(context) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'closeTag.closeHTMLTagInPlace',
-      (args) => {
-        const textEditor = vscode.window.activeTextEditor;
-        if (!textEditor) return;
-        const previousSelections = textEditor.selections;
-        textEditor.edit((edit) => {
-          closeSelections(textEditor, edit, args);
-        }).then(() => {
-          const currentSelections = textEditor.selections;
+      async (args) => {
+        const { activeTextEditor: textEditor } = vscode.window;
 
-          previousSelections.forEach((selection, i) => {
+        if (textEditor) {
+          const prevSelections = textEditor.selections;
+
+          await textEditor.edit(edit => {
+            closeSelections(textEditor, edit, args);
+          });
+
+          prevSelections.forEach((selection, index) => {
             // If a range of text was selected previously, then just keep it
             // since the new replacement text will be selected already.
             // Otherwise, restore the previous cursor position.
+
             if (selection.isEmpty) {
-              currentSelections[i] = selection;
+              textEditor.selections[index] = selection;
             }
           });
-
-          textEditor.selections = currentSelections;
-        });
+        }
       }
     )
   );

--- a/extension.js
+++ b/extension.js
@@ -26,14 +26,28 @@ function activate(context) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerTextEditorCommand(
+    vscode.commands.registerCommand(
       'closeTag.closeHTMLTagInPlace',
-      (textEditor, edit, args) => {
-        const newSelections = textEditor.selections;
+      (args) => {
+        const textEditor = vscode.window.activeTextEditor;
+        if (!textEditor) return;
+        const previousSelections = textEditor.selections;
+        textEditor.edit((edit) => {
+          closeSelections(textEditor, edit, args);
+        }).then(() => {
+          const currentSelections = textEditor.selections;
 
-        closeSelections(textEditor, edit, args);
+          previousSelections.forEach((selection, i) => {
+            // If a range of text was selected previously, then just keep it
+            // since the new replacement text will be selected already.
+            // Otherwise, restore the previous cursor position.
+            if (selection.isEmpty) {
+              currentSelections[i] = selection;
+            }
+          });
 
-        textEditor.selections = newSelections;
+          textEditor.selections = currentSelections;
+        });
       }
     )
   );

--- a/test/baseline/multipleCloseTagsInPlaceInsert.xml
+++ b/test/baseline/multipleCloseTagsInPlaceInsert.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre></genre>Computer</genre>
+      <price></price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies,
+      an evil sorceress, and her own childhood to become queen
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology
+      society in England, the young survivors lay the
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious
+      agent known only as Oberon helps to create a new life
+      for the inhabitants of London. Sequel to Maeve
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters,
+      battle one another for control of England. Sequel to
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in
+      detail, with attention to XML DOM interfaces, XSLT processing,
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are
+      integrated into a comprehensive development
+      environment.</description>
+   </book>
+</catalog>

--- a/test/baseline/simpleCloseTagInPlaceInsert.xml
+++ b/test/baseline/simpleCloseTagInPlaceInsert.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre></genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies,
+      an evil sorceress, and her own childhood to become queen
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology
+      society in England, the young survivors lay the
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious
+      agent known only as Oberon helps to create a new life
+      for the inhabitants of London. Sequel to Maeve
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters,
+      battle one another for control of England. Sequel to
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in
+      detail, with attention to XML DOM interfaces, XSLT processing,
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are
+      integrated into a comprehensive development
+      environment.</description>
+   </book>
+</catalog>

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -79,18 +79,39 @@ describe('Extension Test', () => {
       });
     });
 
-    describe('Close tags in-place at (5, 13)-(5, 16) and (6, 13)-(6, 16)', () => {
+    describe('Close tags in-place at (5, 13)', () => {
+      beforeEach(() => {
+        textEditor.selection = new Selection(5, 13, 5, 13);
+
+        return commands.executeCommand('closeTag.closeHTMLTagInPlace');
+      });
+
+      it('should close as expected', () => {
+        return assertContent(textEditor.document, 'simpleCloseTagInPlaceInsert.xml');
+      });
+
+      it('should not move cursor', () => {
+        const { selection } = textEditor;
+
+        assert.equal(selection.anchor.line, 5);
+        assert.equal(selection.anchor.character, 13);
+        assert.equal(selection.active.line, 5);
+        assert.equal(selection.active.character, 13);
+      });
+    });
+
+    describe('Close tags in-place at (5, 13) and (6, 13)', () => {
       beforeEach(() => {
         textEditor.selections = [
-          new Selection(5, 13, 5, 16),
-          new Selection(6, 13, 6, 16)
+          new Selection(5, 13, 5, 13),
+          new Selection(6, 13, 6, 13)
         ];
 
         return commands.executeCommand('closeTag.closeHTMLTagInPlace');
       });
 
       it('should close as expected', () => {
-        return assertContent(textEditor.document, 'multipleCloseTagsInPlace.xml');
+        return assertContent(textEditor.document, 'multipleCloseTagsInPlaceInsert.xml');
       });
 
       it('should select newly closed tags', () => {
@@ -99,12 +120,12 @@ describe('Extension Test', () => {
         assert.equal(selections[0].anchor.line, 5);
         assert.equal(selections[0].anchor.character, 13);
         assert.equal(selections[0].active.line, 5);
-        assert.equal(selections[0].active.character, 21);
+        assert.equal(selections[0].active.character, 13);
 
         assert.equal(selections[1].anchor.line, 6);
         assert.equal(selections[1].anchor.character, 13);
         assert.equal(selections[1].active.line, 6);
-        assert.equal(selections[1].active.character, 21);
+        assert.equal(selections[1].active.character, 13);
       });
     });
 


### PR DESCRIPTION
Proposed fix for https://github.com/compulim/vscode-closetag/issues/11.  Tested in VS Code 1.13.1 with single and multiple cursors, both with and without empty selections.

Now when closeTag.closeHTMLTagInPlace is called with an empty selection (just a cursor), the cursor stays in place before the closing tag as expected.  Also, if there is a non-empty selection and the selected text is replaced with the closing tag, then the closing tag will remain selected.
